### PR TITLE
refactoring Contract to transfer from the contract address itself ins…

### DIFF
--- a/backend/contracts/Contract.sol
+++ b/backend/contracts/Contract.sol
@@ -131,7 +131,7 @@ contract NFTRaffleContract is VRFConsumerBaseV2 {
         address winner = playerSelector[winnerIndex];
         emit WinnerSelected(winner);
 
-        ERC721Base(nftAddress).transferFrom(owner, winner, nftId);
+        ERC721Base(nftAddress).transferFrom(address(this), winner, nftId);
         resetContract();
     }
 

--- a/frontend/components/AdminEntryCost.tsx
+++ b/frontend/components/AdminEntryCost.tsx
@@ -46,6 +46,7 @@ const AdminEntryCost = () => {
           ])
         }
         isDisabled={raffleStatus}
+        onSuccess={resetEntryCost}
       >
         Update Entry Cost
       </Web3Button>

--- a/frontend/components/AdminTransferNFT.tsx
+++ b/frontend/components/AdminTransferNFT.tsx
@@ -26,10 +26,7 @@ const AdminTransferNFT: React.FC<TransferNFTProps> = ({
     "raffleStatus",
   );
 
-  const { contract: prizeNFTContract } = useContract(
-    nftContractAddress,
-    "nft-drop",
-  );
+  const { contract: prizeNFTContract } = useContract(nftContractAddress);
 
   const { data: prizeNFTContractMetadata } =
     useContractMetadata(prizeNFTContract);
@@ -65,14 +62,9 @@ const AdminTransferNFT: React.FC<TransferNFTProps> = ({
       <Web3Button
         contractAddress={RAFFLE_CONTRACT_ADDRESS}
         action={async () => {
-          await prizeNFTContract?.setApprovalForToken(
-            RAFFLE_CONTRACT_ADDRESS,
-            tokenId,
-          );
-
           await raffleContract?.call("selectWinner");
         }}
-        isDisabled={!raffleStatus}
+        isDisabled={raffleStatus}
       >
         Select Winner
       </Web3Button>

--- a/frontend/components/AdminWithdrawBalance.tsx
+++ b/frontend/components/AdminWithdrawBalance.tsx
@@ -26,7 +26,6 @@ const AdminWithdrawBalance = () => {
       <Web3Button
         contractAddress={RAFFLE_CONTRACT_ADDRESS}
         action={(contract) => contract.call("withdrawBalance")}
-        isDisabled={true}
       >
         Withdraw Balance
       </Web3Button>

--- a/frontend/components/CurrentEntries.tsx
+++ b/frontend/components/CurrentEntries.tsx
@@ -1,0 +1,25 @@
+import { useContract, useContractRead } from "@thirdweb-dev/react";
+import React from "react";
+import { RAFFLE_CONTRACT_ADDRESS } from "../const/addresses";
+import { Container } from "@chakra-ui/react";
+import EntryCard from "./EntryCard";
+
+const CurrentEntries = () => {
+  const { contract } = useContract(RAFFLE_CONTRACT_ADDRESS);
+
+  const { data: currentEntries, isLoading: isLoadingCurrentEntries } =
+    useContractRead(contract, "getPlayers");
+  return (
+    <Container py={8}>
+      {!isLoadingCurrentEntries &&
+        currentEntries.map((entry: string, index: number) => (
+          <EntryCard
+            key={index}
+            walletAddress={entry}
+          />
+        ))}
+    </Container>
+  );
+};
+
+export default CurrentEntries;

--- a/frontend/components/EntryCard.tsx
+++ b/frontend/components/EntryCard.tsx
@@ -1,0 +1,41 @@
+import { Card, Flex, Text } from "@chakra-ui/react";
+import { useContract, useContractRead } from "@thirdweb-dev/react";
+import React from "react";
+import { RAFFLE_CONTRACT_ADDRESS } from "../const/addresses";
+
+type EntryCardProps = {
+  walletAddress: string;
+};
+
+const EntryCard: React.FC<EntryCardProps> = ({ walletAddress }) => {
+  const { contract } = useContract(RAFFLE_CONTRACT_ADDRESS);
+
+  const { data: numberOfEntries, isLoading: isLoadingNumberOfEntries } =
+    useContractRead(contract, "entryCount", [walletAddress]);
+
+  const truncateAddress = (address: string) => {
+    return address.slice(0, 6) + "..." + address.slice(-4);
+  };
+
+  return (
+    <Card>
+      {!isLoadingNumberOfEntries && (
+        <Flex
+          flexDirection={"row"}
+          alignItems={"center"}
+          justifyContent={"space-between"}
+        >
+          <Text
+            border={"1px solid"}
+            borderRadius={"6px"}
+          >
+            {truncateAddress(walletAddress)}
+          </Text>
+          <Text>Entries: {numberOfEntries.toNumber()}</Text>
+        </Flex>
+      )}
+    </Card>
+  );
+};
+
+export default EntryCard;

--- a/frontend/const/addresses.ts
+++ b/frontend/const/addresses.ts
@@ -1,5 +1,5 @@
 export const RAFFLE_CONTRACT_ADDRESS =
-  "0x103574eFF1e05F5F9Ecd2955B2D4543211E49608";
+  "0x7E3168A705fF4e9249d50017467b999f4a06D64F";
 
 export const HERO_IMAGE_URL =
   "ipfs://QmS1gz2fNL6DfnfebNsY3KkdYh3vT4jcEArkndao6eCk5Z/Untitled%20design%20(14).png";

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -21,6 +21,7 @@ import { ethers } from "ethers";
 import RaffleStatus from "../components/RaffleStatus";
 import { useState } from "react";
 import PrizeNFT from "../components/PrizeNFT";
+import CurrentEntries from "../components/CurrentEntries";
 
 const Home: NextPage = () => {
   const address = useAddress();
@@ -151,7 +152,8 @@ const Home: NextPage = () => {
         mt={"40px"}
         textAlign={"center"}
       >
-        <Text fontSize={"xl"}>Current Raffle Participants:</Text>
+        <Text fontSize={"xl"}>Current Raffle Entries:</Text>
+        <CurrentEntries />
       </Stack>
     </Container>
   );


### PR DESCRIPTION
- refactoring Contract to transfer from the contract address itself instead of the contract deployer EOA when selectWinner function is ran
- updating frontend const contract address
- adding CurrentEntries and EntryCard components within frontend, importing within index page
- updating AdminTransferNFT as current ERC721 tokens used in testing do not rely on the raffleContract needing approval to transfer the token
- updating AdminEntryCost Web3Button to have onSuccess as well as updating AdminWithdrawBalance that had withdraw button disabled 